### PR TITLE
warpjs-ipt-plugin #40 new tab button for related reading detail warning

### DIFF
--- a/client/style.less
+++ b/client/style.less
@@ -740,7 +740,8 @@
         justify-content: center;
         align-items: center;
 
-        .save-warning-continue {
+        .save-warning-continue,
+        .save-warning-new-tab {
             background-color: #c7281a;
             border-radius: 3px;
             color: #fff;
@@ -748,6 +749,12 @@
             text-transform: uppercase;
             padding: 7px 30px;
             font-size: 12px;
+            margin-right: 10px;
+        }
+
+        .save-warning-new-tab {
+            margin-right: 0px;
+            margin-left: 10px;
         }
     }
 }

--- a/client/wizard/index.js
+++ b/client/wizard/index.js
@@ -921,6 +921,10 @@ const template = require('./../template.hbs');
                         $(document).on('click', '.save-warning-continue', () => {
                             window.location = $('.content-link').data('url');
                         });
+
+                        $(document).on('click', '.save-warning-new-tab', () => {
+                            window.open($('.content-link').data('url'), '_blank');
+                        });
                     })
                 ;
             }

--- a/client/wizard/warning.hbs
+++ b/client/wizard/warning.hbs
@@ -11,6 +11,7 @@
       </div>
       <div class="modal-body warning-body">
         <button class="save-warning-continue">Continue</button>
+        <button class="save-warning-new-tab">Open in new tab</button>
       </div>
     </div>
   </div>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -7,8 +7,6 @@ const baseConstants = ActionPlugin.baseConstants(packageJson);
 const versionedName = baseConstants.versionedName;
 const versionedNameWizard = `${versionedName}-wizard`;
 
-console.log('versionedNameWizard:: ', versionedNameWizard);
-
 module.exports = Object.freeze(_.extend({}, baseConstants, {
     routes: Object.freeze({
         assets: `${NAMESPACE}:assets`,


### PR DESCRIPTION
Adds a button to the related reading content link warning for opening in new tab.
Also removes console log for versionedNameWizard.